### PR TITLE
feat: add host option. Fix jp region URL.

### DIFF
--- a/cmd/v1-mcp-server/main.go
+++ b/cmd/v1-mcp-server/main.go
@@ -23,6 +23,7 @@ func run() error {
 	readOnly := flag.Bool("readonly", true, "set readonly false to allow the MCP server to perform write operations.")
 	v1Region := flag.String("region", "", "set the region of your vision one account.")
 	showVersion := flag.Bool("version", false, "print version information")
+	host := flag.String("host", "", "set the Trend Vision One endpoint you want to use. Only useful for interacting with internal environments.")
 
 	flag.Parse()
 
@@ -31,13 +32,19 @@ func run() error {
 		return nil
 	}
 
-	if err := validateRegion(*v1Region); err != nil {
-		return err
-	}
-
 	apiKey := os.Getenv("TREND_VISION_ONE_API_KEY")
 	if apiKey == "" {
 		return errors.New("TREND_VISION_ONE_API_KEY not set")
+	}
+
+	if *host != "" && *v1Region != "" {
+		return errors.New("host and region cannot be used together")
+	}
+
+	if *v1Region != "" {
+		if err := validateRegion(*v1Region); err != nil {
+			return err
+		}
 	}
 
 	version := getVersion()
@@ -47,6 +54,7 @@ func run() error {
 		ReadOnly: *readOnly,
 		Region:   *v1Region,
 		Version:  version,
+		Host:     *host,
 	}
 
 	return v1mcp.RunMcpStdioServer(serverCfg)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,14 @@ go 1.23.0
 require (
 	github.com/google/go-querystring v1.1.0
 	github.com/mark3labs/mcp-go v0.27.0
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,5 +26,7 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/v1client/v1client_test.go
+++ b/internal/v1client/v1client_test.go
@@ -1,0 +1,37 @@
+package v1client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewV1ApiClient(t *testing.T) {
+	t.Run("invalid configuration", func(t *testing.T) {
+		require.Panics(t, func() { _, _ = NewV1ApiClient(ClientOptions{}) }, "the function did not panic")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		c, err := NewV1ApiClient(ClientOptions{
+			Region: "au",
+		})
+		require.NotNil(t, c, "expected client instead found nil pointer")
+		require.Nil(t, err, "expected error to be nil")
+		require.Equal(t, "api.au.xdr.trendmicro.com", c.baseUrl.Hostname())
+	})
+
+	t.Run("expect host to be used instead of region", func(t *testing.T) {
+		d, err := NewV1ApiClient(ClientOptions{
+			Region: "au",
+			Host:   "some.trendmicro.com",
+		})
+		require.Nil(t, err)
+		require.Equal(
+			t,
+			"some.trendmicro.com",
+			d.baseUrl.Hostname(),
+			"wanted some.trendmicro.com, got %s",
+			d.baseUrl.Hostname(),
+		)
+	})
+}


### PR DESCRIPTION
## Title

feat: add host option. Fix jp region URL.

## Description

Adds a host option so users can change the endpoint. This would be used, for example, to use staging environment API endpoints.

## Changes

- Add `-host <string>` option for the server.
- Fix `jp` region using the incorrect hostname.

## How to Test

Steps to manually test this PR:

1. `v1-mcp-server -region us -hostname example.com` - Confirm that host and region cannot be used together
2. `go test -v ./...` - Confirm client creation is working as expected


## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests
- [x] I have assigned reviewers
