### PR TITLE
feat: Add Cloud Risk Management APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,9 @@ Used by domains requiring custom headers (e.g., AI Security uses `TMV1-Applicati
 ### Tool Naming Convention
 `{domain}_{resource}_{action}` - e.g., `iam_api_keys_list`, `workbench_alert_detail_get`
 
+### Comments
+Only add comments when something truly needs explanation. Comments should explain "why", not "what". If the code is clear from function names, variable names, and structure, no comment is needed.
+
 ## Domain Organization
 
 | Domain | Client File | Tools File | API Prefix |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ Alternatively, copy the following into your `settings.json`.
 | ---- | ----------- | ---- |
 | `aisecurity_guardrails_apply` | Evaluates prompts against AI guard policies and returns the recommended action (Allow/Block) with reasons for any policy violations detected | `read` |
 
+### Cloud Risk Management
+
+| Tool | Description | Mode |
+| ---- | ----------- | ---- |
+| `cloud_risk_management_accounts_list` | Displays the cloud accounts you can access in a paginated list | `read` |
+| `cloud_risk_management_account_scan_rules_get` | Displays the settings for all rules of the specified account in a paginated list | `read` |
+| `cloud_risk_management_services_list` | Retrieves a list of cloud services and their associated rules supported by Cloud Risk Management | `read` |
+
 ### Threat Intelligence
 
 | Tool | Description | Mode |

--- a/internal/v1client/cloudriskmanagement.go
+++ b/internal/v1client/cloudriskmanagement.go
@@ -1,0 +1,24 @@
+package v1client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// CloudRiskManagementListAccounts lists all cloud accounts.
+// API: GET /v3.0/cloudRiskManagement/accounts
+func (c *V1ApiClient) CloudRiskManagementListAccounts(filter string, queryParams QueryParameters) (*http.Response, error) {
+	return c.searchAndFilter("v3.0/cloudRiskManagement/accounts", filter, queryParams)
+}
+
+// CloudRiskManagementGetAccountScanRules retrieves the scan rule settings for a specific account.
+// API: GET /v3.0/cloudRiskManagement/accounts/{id}/scanRules
+func (c *V1ApiClient) CloudRiskManagementGetAccountScanRules(accountId string, filter string, queryParams QueryParameters) (*http.Response, error) {
+	return c.searchAndFilter(fmt.Sprintf("v3.0/cloudRiskManagement/accounts/%s/scanRules", accountId), filter, queryParams)
+}
+
+// CloudRiskManagementListServices lists cloud services and their associated rules supported by Cloud Risk Management.
+// API: GET /v3.0/cloudRiskManagement/services
+func (c *V1ApiClient) CloudRiskManagementListServices(filter string, queryParams QueryParameters) (*http.Response, error) {
+	return c.searchAndFilter("v3.0/cloudRiskManagement/services", filter, queryParams)
+}

--- a/internal/v1client/cloudriskmanagement.go
+++ b/internal/v1client/cloudriskmanagement.go
@@ -5,20 +5,14 @@ import (
 	"net/http"
 )
 
-// CloudRiskManagementListAccounts lists all cloud accounts.
-// API: GET /v3.0/cloudRiskManagement/accounts
 func (c *V1ApiClient) CloudRiskManagementListAccounts(filter string, queryParams QueryParameters) (*http.Response, error) {
 	return c.searchAndFilter("v3.0/cloudRiskManagement/accounts", filter, queryParams)
 }
 
-// CloudRiskManagementGetAccountScanRules retrieves the scan rule settings for a specific account.
-// API: GET /v3.0/cloudRiskManagement/accounts/{id}/scanRules
 func (c *V1ApiClient) CloudRiskManagementGetAccountScanRules(accountId string, filter string, queryParams QueryParameters) (*http.Response, error) {
 	return c.searchAndFilter(fmt.Sprintf("v3.0/cloudRiskManagement/accounts/%s/scanRules", accountId), filter, queryParams)
 }
 
-// CloudRiskManagementListServices lists cloud services and their associated rules supported by Cloud Risk Management.
-// API: GET /v3.0/cloudRiskManagement/services
 func (c *V1ApiClient) CloudRiskManagementListServices(filter string, queryParams QueryParameters) (*http.Response, error) {
 	return c.searchAndFilter("v3.0/cloudRiskManagement/services", filter, queryParams)
 }

--- a/internal/v1mcp/server.go
+++ b/internal/v1mcp/server.go
@@ -40,6 +40,7 @@ func NewMcpServer(cfg ServerConfig) (*mcpserver.MCPServer, error) {
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyIAM)
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyCREM)
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyCloudPosture)
+	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyCloudRiskManagement)
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyWorkench)
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyCAM)
 	addReadOnlyToolset(s, client, tools.ToolsetsReadOnlyEmail)

--- a/internal/v1mcp/tooldescriptions/descriptions.go
+++ b/internal/v1mcp/tooldescriptions/descriptions.go
@@ -340,6 +340,70 @@ not 	Operator 'not'
 Note: Include this parameter in every request that generates paginated output.
 `
 
+var FilterCloudRiskManagementAccounts = `
+string <= 1783 characters
+Example: provider eq 'aws' or provider eq 'azure'
+
+Filter for retrieving a subset of accounts.
+
+Supported field values:
+
+| Field                   | Description                                 | Possible values                                                     |
+| ----------------------- | ------------------------------------------- | ------------------------------------------------------------------- |
+| provider                | The cloud service provider                  | aws, azure, gcp, alibabaCloud, oci                                  |
+| awsAccountId            | The cloudId of the AWS provider             | Example: "123456789023"                                             |
+| azureSubscriptionId     | The cloudId of the Azure provider           | Example: "be98adad-6385-4323-bf42-c61234215c7c"                     |
+| gcpProjectId            | The cloudId of the GCP provider             | Example: "af66c906-4652-4824-a4f2-f703238af335-my-gcp-project"      |
+| ociCompartmentId        | The cloudId of the OCI provider             | Example: "ocid1.compartment.oc1..aaaaaaaaxxxxxxx"                   |
+| alibabaAccountId        | The cloudId of the Alibaba Cloud provider   | Example: "1234567890123456"                                         |
+
+Supported operators:
+
+| Operator | Description         |
+| -------- | ------------------- |
+| eq       | Operator 'equal to' |
+| or       | Operator 'or'       |
+`
+
+var FilterCloudRiskManagementScanRules = `
+string <= 1783 characters
+Example: isCustomized eq 'true'
+
+Filter for retrieving a subset of rule settings.
+
+Supported field values:
+
+| Field        | Description                                 | Possible values       |
+| ------------ | ------------------------------------------- | --------------------- |
+| isCustomized | Indicates if the rule uses default settings | true, false           |
+
+Supported operators:
+
+| Operator | Description         |
+| -------- | ------------------- |
+| eq       | Operator 'equal to' |
+`
+
+var FilterCloudRiskManagementServices = `
+string <= 1783 characters
+Example: provider eq 'aws'
+
+Filter for retrieving a subset of services.
+
+Supported field values:
+
+| Field    | Description                | Possible values                              |
+| -------- | -------------------------- | -------------------------------------------- |
+| provider | The cloud service provider | aws, azure, gcp, alibabaCloud, oci           |
+
+Supported operators:
+
+| Operator | Description         |
+| -------- | ------------------- |
+| eq       | Operator 'equal to' |
+| or       | Operator 'or'       |
+`
+
 var FilterCloudPostureChecks = `
 string <= 1783 characters
 Examples:

--- a/internal/v1mcp/tools/cloudriskmanagement.go
+++ b/internal/v1mcp/tools/cloudriskmanagement.go
@@ -1,0 +1,139 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/trendmicro/vision-one-mcp-server/internal/v1client"
+	"github.com/trendmicro/vision-one-mcp-server/internal/v1mcp/tooldescriptions"
+)
+
+var ToolsetsReadOnlyCloudRiskManagement = []func(*v1client.V1ApiClient) mcpserver.ServerTool{
+	toolCloudRiskManagementAccountsList,
+	toolCloudRiskManagementAccountScanRulesGet,
+	toolCloudRiskManagementServicesList,
+}
+
+func toolCloudRiskManagementAccountsList(client *v1client.V1ApiClient) mcpserver.ServerTool {
+	return mcpserver.ServerTool{
+		Tool: mcp.NewTool(
+			"cloud_risk_management_accounts_list",
+			mcp.WithDescription("Displays the cloud accounts you can access in a paginated list"),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				ReadOnlyHint: toPtr(true),
+			}),
+			mcp.WithString("filter", mcp.Description(tooldescriptions.FilterCloudRiskManagementAccounts)),
+			mcp.WithNumber("top",
+				mcp.Description(tooldescriptions.DefaultTop),
+				mcp.Min(50),
+				mcp.Max(200),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			top, err := optionalIntValue("top", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			filter, err := optionalValue[string]("filter", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			queryParams := v1client.QueryParameters{
+				Top: top,
+			}
+
+			resp, err := client.CloudRiskManagementListAccounts(filter, queryParams)
+			return handleStatusResponse(
+				resp,
+				err,
+				http.StatusOK,
+				"failed to list cloud accounts",
+			)
+		},
+	}
+}
+
+func toolCloudRiskManagementAccountScanRulesGet(client *v1client.V1ApiClient) mcpserver.ServerTool {
+	return mcpserver.ServerTool{
+		Tool: mcp.NewTool(
+			"cloud_risk_management_account_scan_rules_get",
+			mcp.WithDescription("Displays the settings for all rules of the specified account in a paginated list"),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				ReadOnlyHint: toPtr(true),
+			}),
+			mcp.WithString("accountId",
+				mcp.Required(),
+				mcp.Description("The Cloud Risk Management ID of the account"),
+			),
+			mcp.WithString("filter", mcp.Description(tooldescriptions.FilterCloudRiskManagementScanRules)),
+			mcp.WithNumber("top",
+				mcp.Description(tooldescriptions.DefaultTop),
+				mcp.Min(50),
+				mcp.Max(200),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			accountId, err := requiredValue[string]("accountId", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			top, err := optionalIntValue("top", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			filter, err := optionalValue[string]("filter", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			queryParams := v1client.QueryParameters{
+				Top: top,
+			}
+
+			resp, err := client.CloudRiskManagementGetAccountScanRules(accountId, filter, queryParams)
+			return handleStatusResponse(resp, err, http.StatusOK, "failed to get account scan rules")
+		},
+	}
+}
+
+func toolCloudRiskManagementServicesList(client *v1client.V1ApiClient) mcpserver.ServerTool {
+	return mcpserver.ServerTool{
+		Tool: mcp.NewTool(
+			"cloud_risk_management_services_list",
+			mcp.WithDescription("Retrieves a list of cloud services and their associated rules supported by Cloud Risk Management"),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				ReadOnlyHint: toPtr(true),
+			}),
+			mcp.WithString("filter", mcp.Description(tooldescriptions.FilterCloudRiskManagementServices)),
+			mcp.WithNumber("top",
+				mcp.Description(tooldescriptions.DefaultTop),
+				mcp.Min(50),
+				mcp.Max(200),
+			),
+		),
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			top, err := optionalIntValue("top", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			filter, err := optionalValue[string]("filter", request.GetArguments())
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			queryParams := v1client.QueryParameters{
+				Top: top,
+			}
+
+			resp, err := client.CloudRiskManagementListServices(filter, queryParams)
+			return handleStatusResponse(resp, err, http.StatusOK, "failed to list cloud services")
+		},
+	}
+}


### PR DESCRIPTION
[feat] Add Cloud Risk Management APIs

---

## Description

This PR adds MCP tool support for Trend Vision One Cloud Risk Management APIs. These tools enable users to query cloud accounts, scan rules, and supported cloud services through the MCP interface.

---

## Changes

- Added `internal/v1client/cloudriskmanagement.go` with three API client methods:
  - `CloudRiskManagementListAccounts` - list cloud accounts
  - `CloudRiskManagementGetAccountScanRules` - get scan rules for a specific account
  - `CloudRiskManagementListServices` - list supported cloud services and rules
- Added `internal/v1mcp/tools/cloudriskmanagement.go` with three MCP tools:
  - `cloud_risk_management_accounts_list`
  - `cloud_risk_management_account_scan_rules_get`
  - `cloud_risk_management_services_list`
- Added filter descriptions in `internal/v1mcp/tooldescriptions/descriptions.go`
- Registered new toolset in `internal/v1mcp/server.go`
- Updated `README.md` with Cloud Risk Management tool documentation
- Updated `CLAUDE.md` with guidance on using generic client functions

---

## How to Test

1. Build the server: `make mcpserver`
2. Set `TREND_VISION_ONE_API_KEY` environment variable
3. Run the server: `./bin/v1-mcp-server -region us`
4. Test the new tools via MCP client:
   - Call `cloud_risk_management_accounts_list` to list cloud accounts
   - Call `cloud_risk_management_account_scan_rules_get` with an `accountId`
   - Call `cloud_risk_management_services_list` to list supported services

---

## Screenshots / Demos (if applicable)

<img width="1414" height="186" alt="image" src="https://github.com/user-attachments/assets/48751ef5-21e1-40a8-b904-0ae5201fe8cf" />


---

## Checklist

- [x] I have tested my changes locally
- [x] I have updated relevant documentation
- [x] I have assigned reviewers
